### PR TITLE
Ensure default client ID is unique per ESP device

### DIFF
--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -28,7 +28,7 @@ AsyncMqttClient::AsyncMqttClient()
   _client.onData([](void* obj, AsyncClient* c, void* data, size_t len) { (static_cast<AsyncMqttClient*>(obj))->_onData(c, static_cast<char*>(data), len); }, this);
   _client.onPoll([](void* obj, AsyncClient* c) { (static_cast<AsyncMqttClient*>(obj))->_onPoll(c); }, this);
 
-  sprintf(_generatedClientId, "esp8266%06x", ESP.getFlashChipId());
+  sprintf(_generatedClientId, "esp8266%06x", ESP.getChipId());
   _clientId = _generatedClientId;
 
   setMaxTopicLength(128);


### PR DESCRIPTION
The auto-generated client ID wasn't using a device-specific ID which meant it was possible to end up with lots of devices using the same client ID when connecting to the broker, causing lots of unexpected disconnections.

This commit uses `ESP.getChipId()` to generate a unique client ID string instead of `ESP.getFlashChipId()` which wasn't unique.