### PR TITLE
Overall enhancements to be more resilient to corrupted data links

### DIFF
--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -263,7 +263,8 @@ void AsyncMqttClient::_onError(AsyncClient* client, int8_t error) {
 void AsyncMqttClient::_onTimeout(AsyncClient* client, uint32_t time) {
   (void)client;
   (void)time;
-  _clear();
+  // disconnection will be handled by ping/pong management now
+  //_clear();
 }
 
 void AsyncMqttClient::_onAck(AsyncClient* client, size_t len, uint32_t time) {
@@ -322,7 +323,13 @@ void AsyncMqttClient::_onData(AsyncClient* client, char* data, size_t len) {
         if (currentByte >> 7 == 0) {
           _parsingInformation.remainingLength = AsyncMqttClientInternals::Helpers::decodeRemainingLength(_remainingLengthBuffer);
           _remainingLengthBufferPosition = 0;
-          _parsingInformation.bufferState = AsyncMqttClientInternals::BufferState::VARIABLE_HEADER;
+          if(_parsingInformation.remainingLength>0) {
+            _parsingInformation.bufferState = AsyncMqttClientInternals::BufferState::VARIABLE_HEADER;
+          } else {
+            // PINGRESP is a special case where it has no variable header, so the packet ends right here
+            _parsingInformation.bufferState = AsyncMqttClientInternals::BufferState::NONE;
+            _onPingResp();
+          }
         }
         break;
       case AsyncMqttClientInternals::BufferState::VARIABLE_HEADER:
@@ -338,30 +345,27 @@ void AsyncMqttClient::_onData(AsyncClient* client, char* data, size_t len) {
 }
 
 void AsyncMqttClient::_onPoll(AsyncClient* client) {
-  // if there is too much time the client has sent a ping request without a response, disconnect client to avoid half open connections
-  if (_connected && _lastPingRequestTime!=0 && (millis() - _lastPingRequestTime) >= (_keepAlive * 1000 * 2)) {
-    Serial.println(">>>>>>>> DISCONNECTING FROM MQTT SERVER BECAUSE OF NO REPLY");
-    disconnect();
-  }
-parei aqui... aparentemente o ping chega ao servidor (que sempre responde), mas a resposta não está chegando de volta...
-  // send ping to ensure the server will receive at least one message inside keepalive window
-  if (_connected && _lastPingRequestTime==0 && millis() - _lastClientActivity >= (_keepAlive * 1000 * 0.7)) {
-    Serial.println(">>>>>>>> SENDING PING FOR CLIENT VERIFICATION");
-    _sendPing();
+  if (_connected) {
+    // if there is too much time the client has sent a ping request without a response, disconnect client to avoid half open connections
+    if(_lastPingRequestTime!=0 && (millis() - _lastPingRequestTime) >= (_keepAlive * 1000 * 2)) {
+      disconnect();
+
+    // send ping to ensure the server will receive at least one message inside keepalive window
+    } else if (_lastPingRequestTime==0 && (millis() - _lastClientActivity) >= (_keepAlive * 1000 * 0.7)) {
+      _sendPing();
+
+    // send ping to verify if the server is still there (ensure this is not a half connection)
+    } else if (_connected && _lastPingRequestTime==0 && (millis() - _lastServerActivity) >= (_keepAlive * 1000 * 0.7)) {
+      _sendPing();
+    }
   }
 
-  // send ping to verify if the server is still there (ensure this is not a half connection)
-  if (_connected && _lastPingRequestTime==0 && millis() - _lastServerActivity >= (_keepAlive * 1000 * 0.7)) {
-    Serial.println(">>>>>>>> SENDING PING FOR SERVER VERIFICATION");
-    _sendPing();
-  }
 }
 
 /* MQTT */
 void AsyncMqttClient::_onPingResp() {
   _freeCurrentParsedPacket();
   _lastPingRequestTime = 0;
-  Serial.println(">>>>>>>> RECEIVED PING RESPONSE FROM SERVER");
 }
 
 void AsyncMqttClient::_onConnAck(bool sessionPresent, uint8_t connectReturnCode) {

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -264,7 +264,7 @@ void AsyncMqttClient::_onTimeout(AsyncClient* client, uint32_t time) {
   (void)client;
   (void)time;
   // disconnection will be handled by ping/pong management now
-  //_clear();
+  // _clear();
 }
 
 void AsyncMqttClient::_onAck(AsyncClient* client, size_t len, uint32_t time) {
@@ -323,7 +323,7 @@ void AsyncMqttClient::_onData(AsyncClient* client, char* data, size_t len) {
         if (currentByte >> 7 == 0) {
           _parsingInformation.remainingLength = AsyncMqttClientInternals::Helpers::decodeRemainingLength(_remainingLengthBuffer);
           _remainingLengthBufferPosition = 0;
-          if(_parsingInformation.remainingLength>0) {
+          if (_parsingInformation.remainingLength > 0) {
             _parsingInformation.bufferState = AsyncMqttClientInternals::BufferState::VARIABLE_HEADER;
           } else {
             // PINGRESP is a special case where it has no variable header, so the packet ends right here
@@ -347,19 +347,18 @@ void AsyncMqttClient::_onData(AsyncClient* client, char* data, size_t len) {
 void AsyncMqttClient::_onPoll(AsyncClient* client) {
   if (_connected) {
     // if there is too much time the client has sent a ping request without a response, disconnect client to avoid half open connections
-    if(_lastPingRequestTime!=0 && (millis() - _lastPingRequestTime) >= (_keepAlive * 1000 * 2)) {
+    if (_lastPingRequestTime != 0 && (millis() - _lastPingRequestTime) >= (_keepAlive * 1000 * 2)) {
       disconnect();
 
     // send ping to ensure the server will receive at least one message inside keepalive window
-    } else if (_lastPingRequestTime==0 && (millis() - _lastClientActivity) >= (_keepAlive * 1000 * 0.7)) {
+    } else if (_lastPingRequestTime == 0 && (millis() - _lastClientActivity) >= (_keepAlive * 1000 * 0.7)) {
       _sendPing();
 
     // send ping to verify if the server is still there (ensure this is not a half connection)
-    } else if (_connected && _lastPingRequestTime==0 && (millis() - _lastServerActivity) >= (_keepAlive * 1000 * 0.7)) {
+    } else if (_connected && _lastPingRequestTime == 0 && (millis() - _lastServerActivity) >= (_keepAlive * 1000 * 0.7)) {
       _sendPing();
     }
   }
-
 }
 
 /* MQTT */

--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -58,7 +58,9 @@ class AsyncMqttClient {
   AsyncClient _client;
 
   bool _connected;
-  uint32_t _lastActivity;
+  uint32_t _lastClientActivity;
+  uint32_t _lastServerActivity;
+  uint32_t _lastPingRequestTime;
 
   char _generatedClientId[13 + 1];  // esp8266abc123
   IPAddress _ip;

--- a/src/AsyncMqttClient/Packets/PingRespPacket.cpp
+++ b/src/AsyncMqttClient/Packets/PingRespPacket.cpp
@@ -13,8 +13,6 @@ PingRespPacket::~PingRespPacket() {
 void PingRespPacket::parseVariableHeader(char* data, size_t len, size_t* currentBytePosition) {
   (void)data;
   (void)currentBytePosition;
-  _parsingInformation->bufferState = BufferState::NONE;
-  _callback();
 }
 
 void PingRespPacket::parsePayload(char* data, size_t len, size_t* currentBytePosition) {


### PR DESCRIPTION
I've been doing a lot of stress tests to the product we are working on and found a few things that could enhance MQTT client stability. We encountered various situations where client gets stuck on endless loops or with incorrect information regarding to connection status. Hope it helps.