### PR TITLE
SSL support

### DIFF
--- a/docs/2.-API-reference.md
+++ b/docs/2.-API-reference.md
@@ -68,7 +68,7 @@ Whether or not to use SSL. Defaults to `false`.
 
 * **`secure`**: SSL wanted or not.
 
-#### AsyncMqttClient& setServerFingerprint(const uint8_t\* `fingerprint`)
+#### AsyncMqttClient& addServerFingerprint(const uint8_t\* `fingerprint`)
 
 Adds an acceptable server fingerprint. This may be called multiple times to permit any one of the specified fingerprints. By default, if no fingerprint is added, any fingerprint is accepted.
 

--- a/docs/2.-API-reference.md
+++ b/docs/2.-API-reference.md
@@ -62,6 +62,18 @@ Set the server.
 * **`host`**: Host of the server
 * **`port`**: Port of the server
 
+#### AsyncMqttClient& setSecure(bool `secure`)
+
+Whether or not to use SSL. Defaults to `false`.
+
+* **`secure`**: SSL wanted or not.
+
+#### AsyncMqttClient& setServerFingerprint(const uint8_t\* `fingerprint`)
+
+Adds an acceptable server fingerprint. This may be called multiple times to permit any one of the specified fingerprints. By default, if no fingerprint is added, any fingerprint is accepted.
+
+* **`fingerprint`**: Fingerprint to add
+
 ### Events handlers
 
 #### AsyncMqttClient& onConnect(AsyncMqttClientInternals::OnConnectUserCallback `callback`)

--- a/docs/3.-Limitations-and-known-issues.md
+++ b/docs/3.-Limitations-and-known-issues.md
@@ -9,4 +9,7 @@
 This means retransmission is not honored in case of a failure.
 
 * You cannot send payload larger that what can fit on RAM.
-* SSL is not doable at the moment.
+* SSL requires use of esp8266/Arduino 2.4.0, which is not yet released.
+* SSL requires the build flag -DASYNC_TCP_SSL_ENABLED=1
+* SSL only support fingerprints for server validation.
+* If you do not specify one or more acceptable server fingerprints, the SSL connection will be vulnerable to man-in-the-middle attacks.

--- a/docs/3.-Limitations-and-known-issues.md
+++ b/docs/3.-Limitations-and-known-issues.md
@@ -9,7 +9,7 @@
 This means retransmission is not honored in case of a failure.
 
 * You cannot send payload larger that what can fit on RAM.
-* SSL requires use of esp8266/Arduino 2.4.0, which is not yet released.
+* SSL requires use of esp8266/Arduino 2.4.0, which is not yet released (platform = espressif8266_stage in PlatformIO).
 * SSL requires the build flag -DASYNC_TCP_SSL_ENABLED=1
 * SSL only support fingerprints for server validation.
 * If you do not specify one or more acceptable server fingerprints, the SSL connection will be vulnerable to man-in-the-middle attacks.

--- a/keywords.txt
+++ b/keywords.txt
@@ -17,6 +17,8 @@ setMaxTopicLength	KEYWORD2
 setCredentials	KEYWORD2
 setWill	KEYWORD2
 setServer	KEYWORD2
+setSecure	KEYWORD2
+addServerFingerprin	KEYWORD2
 
 onConnect	KEYWORD2
 onDisconnect	KEYWORD2

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -7,6 +7,9 @@ AsyncMqttClient::AsyncMqttClient()
 , _lastPingRequestTime(0)
 , _host(nullptr)
 , _useIp(false)
+#if ASYNC_TCP_SSL_ENABLED
+, _secure(false)
+#endif
 , _port(0)
 , _keepAlive(15)
 , _cleanSession(true)
@@ -91,6 +94,13 @@ AsyncMqttClient& AsyncMqttClient::setServer(const char* host, uint16_t port) {
   _port = port;
   return *this;
 }
+
+#if ASYNC_TCP_SSL_ENABLED
+AsyncMqttClient& AsyncMqttClient::setSecure(bool secure) {
+  _secure = secure;
+  return *this;
+}
+#endif
 
 AsyncMqttClient& AsyncMqttClient::onConnect(AsyncMqttClientInternals::OnConnectUserCallback callback) {
   _onConnectUserCallbacks.push_back(callback);
@@ -551,11 +561,19 @@ bool AsyncMqttClient::connected() const {
 void AsyncMqttClient::connect() {
   if (_connected) return;
 
+#if ASYNC_TCP_SSL_ENABLED
+  if (_useIp) {
+    _client.connect(_ip, _port, _secure);
+  } else {
+    _client.connect(_host, _port, _secure);
+  }
+#else
   if (_useIp) {
     _client.connect(_ip, _port);
   } else {
     _client.connect(_host, _port);
   }
+#endif
 }
 
 void AsyncMqttClient::disconnect() {

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -102,7 +102,7 @@ AsyncMqttClient& AsyncMqttClient::setSecure(bool secure) {
 }
 
 AsyncMqttClient& AsyncMqttClient::setServerFingerprint(const uint8_t* fingerprint) {
-  std::array<uint8_t,SHA1_SIZE> newFingerprint;
+  std::array<uint8_t, SHA1_SIZE> newFingerprint;
   memcpy(newFingerprint.data(), fingerprint, SHA1_SIZE);
   _secureServerFingerprints.push_back(newFingerprint);
   return *this;
@@ -164,7 +164,7 @@ void AsyncMqttClient::_onConnect(AsyncClient* client) {
     bool sslFoundFingerprint = false;
     SSL* clientSsl = _client.getSSL();
     const uint8_t* fingerprint;
-    for (std::vector<std::array<uint8_t,SHA1_SIZE>>::iterator it = _secureServerFingerprints.begin(); it != _secureServerFingerprints.end(); ++it) {
+    for (std::vector<std::array<uint8_t, SHA1_SIZE>>::iterator it = _secureServerFingerprints.begin(); it != _secureServerFingerprints.end(); ++it) {
       fingerprint = it->data();
       if (ssl_match_fingerprint(clientSsl, fingerprint) == SSL_OK) {
         sslFoundFingerprint = true;

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -101,9 +101,9 @@ AsyncMqttClient& AsyncMqttClient::setSecure(bool secure) {
   return *this;
 }
 
-AsyncMqttClient& AsyncMqttClient::setServerFingerprint(const uint8_t* fp) {
+AsyncMqttClient& AsyncMqttClient::setServerFingerprint(const uint8_t* fingerprint) {
   std::array<uint8_t,SHA1_SIZE> newFingerprint;
-  memcpy(newFingerprint.data(),fp,SHA1_SIZE);
+  memcpy(newFingerprint.data(), fingerprint, SHA1_SIZE);
   _secureServerFingerprints.push_back(newFingerprint);
   return *this;
 }
@@ -162,22 +162,18 @@ void AsyncMqttClient::_onConnect(AsyncClient* client) {
 #if ASYNC_TCP_SSL_ENABLED
   if (_secure && _secureServerFingerprints.size() > 0) {
     bool sslFoundFingerprint = false;
-
     SSL* clientSsl = _client.getSSL();
     const uint8_t* fingerprint;
-
     for (std::vector<std::array<uint8_t,SHA1_SIZE>>::iterator it = _secureServerFingerprints.begin(); it != _secureServerFingerprints.end(); ++it) {
       fingerprint = it->data();
-      if ( ssl_match_fingerprint(clientSsl, fingerprint) == SSL_OK ) {
+      if (ssl_match_fingerprint(clientSsl, fingerprint) == SSL_OK) {
         sslFoundFingerprint = true;
       }
     }
-
     if (!sslFoundFingerprint) {
       _client.close();
       return;
     }
-
   }
 #endif
 

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -101,7 +101,7 @@ AsyncMqttClient& AsyncMqttClient::setSecure(bool secure) {
   return *this;
 }
 
-AsyncMqttClient& AsyncMqttClient::setServerFingerprint(const uint8_t* fingerprint) {
+AsyncMqttClient& AsyncMqttClient::addServerFingerprint(const uint8_t* fingerprint) {
   std::array<uint8_t, SHA1_SIZE> newFingerprint;
   memcpy(newFingerprint.data(), fingerprint, SHA1_SIZE);
   _secureServerFingerprints.push_back(newFingerprint);
@@ -171,7 +171,7 @@ void AsyncMqttClient::_onConnect(AsyncClient* client) {
       }
     }
     if (!sslFoundFingerprint) {
-      _client.close();
+      _client.close(true);
       return;
     }
   }

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -160,7 +160,7 @@ void AsyncMqttClient::_onConnect(AsyncClient* client) {
   (void)client;
 
 #if ASYNC_TCP_SSL_ENABLED
-  if (_secureServerFingerprints.size() > 0) {
+  if (_secure && _secureServerFingerprints.size() > 0) {
     bool sslFoundFingerprint = false;
 
     SSL* clientSsl = _client.getSSL();

--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -7,6 +7,11 @@
 
 #include <ESPAsyncTCP.h>
 
+#if ASYNC_TCP_SSL_ENABLED
+#include <tcp_axtls.h>
+#define SHA1_SIZE 20
+#endif
+
 #include "AsyncMqttClient/Flags.hpp"
 #include "AsyncMqttClient/ParsingInformation.hpp"
 #include "AsyncMqttClient/MessageProperties.hpp"
@@ -41,6 +46,7 @@ class AsyncMqttClient {
   AsyncMqttClient& setServer(const char* host, uint16_t port);
 #if ASYNC_TCP_SSL_ENABLED
   AsyncMqttClient& setSecure(bool secure);
+  AsyncMqttClient& setServerFingerprint(const uint8_t* fp);
 #endif
 
   AsyncMqttClient& onConnect(AsyncMqttClientInternals::OnConnectUserCallback callback);
@@ -83,6 +89,10 @@ class AsyncMqttClient {
   uint16_t _willPayloadLength;
   uint8_t _willQos;
   bool _willRetain;
+
+#if ASYNC_TCP_SSL_ENABLED
+  std::vector<std::array<uint8_t,SHA1_SIZE>> _secureServerFingerprints;
+#endif
 
   std::vector<AsyncMqttClientInternals::OnConnectUserCallback> _onConnectUserCallbacks;
   std::vector<AsyncMqttClientInternals::OnDisconnectUserCallback> _onDisconnectUserCallbacks;

--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -39,6 +39,9 @@ class AsyncMqttClient {
   AsyncMqttClient& setWill(const char* topic, uint8_t qos, bool retain, const char* payload = nullptr, size_t length = 0);
   AsyncMqttClient& setServer(IPAddress ip, uint16_t port);
   AsyncMqttClient& setServer(const char* host, uint16_t port);
+#if ASYNC_TCP_SSL_ENABLED
+  AsyncMqttClient& setSecure(bool secure);
+#endif
 
   AsyncMqttClient& onConnect(AsyncMqttClientInternals::OnConnectUserCallback callback);
   AsyncMqttClient& onDisconnect(AsyncMqttClientInternals::OnDisconnectUserCallback callback);
@@ -66,6 +69,9 @@ class AsyncMqttClient {
   IPAddress _ip;
   const char* _host;
   bool _useIp;
+#if ASYNC_TCP_SSL_ENABLED
+  bool _secure;
+#endif
   uint16_t _port;
   uint16_t _keepAlive;
   bool _cleanSession;

--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -46,7 +46,7 @@ class AsyncMqttClient {
   AsyncMqttClient& setServer(const char* host, uint16_t port);
 #if ASYNC_TCP_SSL_ENABLED
   AsyncMqttClient& setSecure(bool secure);
-  AsyncMqttClient& setServerFingerprint(const uint8_t* fingerprint);
+  AsyncMqttClient& addServerFingerprint(const uint8_t* fingerprint);
 #endif
 
   AsyncMqttClient& onConnect(AsyncMqttClientInternals::OnConnectUserCallback callback);

--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -91,7 +91,7 @@ class AsyncMqttClient {
   bool _willRetain;
 
 #if ASYNC_TCP_SSL_ENABLED
-  std::vector<std::array<uint8_t,SHA1_SIZE>> _secureServerFingerprints;
+  std::vector<std::array<uint8_t, SHA1_SIZE>> _secureServerFingerprints;
 #endif
 
   std::vector<AsyncMqttClientInternals::OnConnectUserCallback> _onConnectUserCallbacks;

--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -46,7 +46,7 @@ class AsyncMqttClient {
   AsyncMqttClient& setServer(const char* host, uint16_t port);
 #if ASYNC_TCP_SSL_ENABLED
   AsyncMqttClient& setSecure(bool secure);
-  AsyncMqttClient& setServerFingerprint(const uint8_t* fp);
+  AsyncMqttClient& setServerFingerprint(const uint8_t* fingerprint);
 #endif
 
   AsyncMqttClient& onConnect(AsyncMqttClientInternals::OnConnectUserCallback callback);


### PR DESCRIPTION
Add support for SSL connections.
Requires esp8266/Arduino 2.4.0, which is not yet released (platform = espressif8266_stage in PlatformIO).
Requires SSL to be explicitly enabled via build_flags (build_flags = -DASYNC_TCP_SSL_ENABLED=1 in PlatformIO).
Fingerprint checking is supported.