### PR TITLE
Update library.json to use ESPAsyncTCP 1.0.x (fixes compilation)

### DIFF
--- a/library.json
+++ b/library.json
@@ -12,13 +12,13 @@
     "type": "git",
     "url": "https://github.com/marvinroger/async-mqtt-client.git"
   },
-  "version": "0.8.1",
+  "version": "0.8.2",
   "frameworks": "arduino",
   "platforms": "espressif",
   "dependencies": [
     {
       "name": "ESPAsyncTCP",
-      "version": "^1.0.1"
+      "version": "~1.0.1"
     }
   ]
 }


### PR DESCRIPTION
ESPAsyncTCP 1.1.0 is incompatible to async-mqtt-client 0.8.1 (compilation error)
So I changed dependency to 1.0.x .