### PR TITLE
fix confusing disconnect event

### DIFF
--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -333,8 +333,6 @@ void AsyncMqttClient::_onConnect(AsyncClient* client) {
 
 void AsyncMqttClient::_onDisconnect(AsyncClient* client) {
   (void)client;
-  AsyncMqttClientDisconnectReason reason;
-
   if (!_disconnectFlagged) {
     AsyncMqttClientDisconnectReason reason;
 


### PR DESCRIPTION
When disconnected due to non-zero connectReturnCode, the _onDisconnectUserCallbacks are dispatched twice: first time with correct reason code, second time with 0. This makes the user disconnection handler very confused... :P