### PR TITLE
Try to flush buffer if we are disconnecting gracefully

### DIFF
--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -704,6 +704,7 @@ void AsyncMqttClient::disconnect(bool force) {
   } else {
     _disconnectFlagged = true;
     _sendDisconnect();
+    _client.send();
   }
 }
 


### PR DESCRIPTION
If this library is used and packets are sent from nodes running on
battery and using deep sleep I was getting inconsistent results trying
to send out packets before going to sleep.

Without this patch I would have to delay between 500 - 2500ms after sending to guarantee to make sure the packets made it out.   With this in I get consistent results of the packets leaving without having to add arbitrary delays.