### PR TITLE
Fix crash on AsyncMqttClient::disconnect

### DIFF
--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -704,7 +704,6 @@ void AsyncMqttClient::disconnect(bool force) {
   } else {
     _disconnectFlagged = true;
     _sendDisconnect();
-    _client.send();
   }
 }
 


### PR DESCRIPTION
Function `_sendDisconnect()` closes connection on line 661
https://github.com/marvinroger/async-mqtt-client/blob/33cdd5038b8b411db47322908ca4eb503f630909/src/AsyncMqttClient.cpp#L661, so `_client.send()` on line 771 https://github.com/marvinroger/async-mqtt-client/blob/33cdd5038b8b411db47322908ca4eb503f630909/src/AsyncMqttClient.cpp#L707 after calling `_sendDisconnect()` on method `AsyncMqttClient::disconnect` crashes.

This sketch shows the error.

```
#include <ESP8266WiFi.h>
#include <AsyncMqttClient.h>

#define WIFI_SSID "---"
#define WIFI_PASSWORD "---"

#define MQTT_HOST IPAddress(192, 168, 5, 1)
#define MQTT_PORT 1883

AsyncMqttClient mqttClient;
WiFiEventHandler wifiConnectHandler;

void onWifiConnect(const WiFiEventStationModeGotIP& event) {
  Serial.println("Connected to Wi-Fi.");
  Serial.println("Connecting to MQTT...");
  mqttClient.connect();
}

void onMqttConnect(bool sessionPresent) {
  Serial.println("Connected to MQTT.");
  Serial.println("Disconecting from MQTT ...");
  mqttClient.disconnect();
  Serial.println("Disconected from MQTT successfully");
}

void onMqttDisconnect(AsyncMqttClientDisconnectReason reason) {
  Serial.println("Disconected from MQTT");
}

void setup() {
  Serial.begin(115200);
  Serial.println();

  wifiConnectHandler = WiFi.onStationModeGotIP(onWifiConnect);

  mqttClient.onConnect(onMqttConnect);
  mqttClient.onDisconnect(onMqttDisconnect);
  mqttClient.setServer(MQTT_HOST, MQTT_PORT);

  Serial.println("Connecting to Wi-Fi...");
  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
}

void loop() {
}
```
This the output before

```
Connecting to Wi-Fi...
Connected to Wi-Fi.
Connecting to MQTT...
Connected to MQTT.
Disconecting from MQTT ...
Disconected from MQTT

Exception (28):
epc1=0x40211096 epc2=0x00000000 epc3=0x00000000 excvaddr=0x0000004c depc=0x00000000

ctx: sys 
sp: 3fffeb50 end: 3fffffb0 offset: 01a0

>>>stack>>>
...
...
...
<<<stack<<<

 ets Jan  8 2013,rst cause:2, boot mode:(3,7)

load 0x4010f000, len 1384, room 16 
tail 8
chksum 0x2d
csum 0x2d
v00000000
~ld
```
and after

```
Connecting to Wi-Fi...
Connected to Wi-Fi.
Connecting to MQTT...
Connected to MQTT.
Disconecting from MQTT ...
Disconected from MQTT
Disconected from MQTT successfully
```

removing line

https://github.com/marvinroger/async-mqtt-client/blob/33cdd5038b8b411db47322908ca4eb503f630909/src/AsyncMqttClient.cpp#L707

