### PR TITLE
#99 fix mqtt.disconnect()

### DIFF
--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -704,7 +704,6 @@ void AsyncMqttClient::disconnect(bool force) {
   } else {
     _disconnectFlagged = true;
     _sendDisconnect();
-    _client.send();
   }
 }
 


### PR DESCRIPTION
This is the fix proposed in #99 for the crash on disconnect(). It worked for me.