### PR TITLE
fix sending malformed packets with mutex

### DIFF
--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -38,6 +38,7 @@ AsyncMqttClient::AsyncMqttClient()
 
 #ifdef ESP32
   sprintf(_generatedClientId, "esp32%06x", ESP.getEfuseMac());
+  _xSemaphore = xSemaphoreCreateMutex();
 #elif defined(ESP8266)
   sprintf(_generatedClientId, "esp8266%06x", ESP.getChipId());
 #endif
@@ -49,6 +50,9 @@ AsyncMqttClient::AsyncMqttClient()
 AsyncMqttClient::~AsyncMqttClient() {
   delete _currentParsedPacket;
   delete[] _parsingInformation.topicBuffer;
+#ifdef ESP32
+  vSemaphoreDelete(_xSemaphore);
+#endif
 }
 
 AsyncMqttClient& AsyncMqttClient::setKeepAlive(uint16_t keepAlive) {
@@ -298,9 +302,11 @@ void AsyncMqttClient::_onConnect(AsyncClient* client) {
     neededSpace += passwordLength;
   }
 
+  SEMAPHORE_TAKE();
   if (_client.space() < neededSpace) {
     _connectPacketNotEnoughSpace = true;
     _client.close(true);
+    SEMAPHORE_GIVE();
     return;
   }
 
@@ -329,6 +335,7 @@ void AsyncMqttClient::_onConnect(AsyncClient* client) {
   }
   _client.send();
   _lastClientActivity = millis();
+  SEMAPHORE_GIVE();
 }
 
 void AsyncMqttClient::_onDisconnect(AsyncClient* client) {
@@ -606,19 +613,22 @@ bool AsyncMqttClient::_sendPing() {
 
   size_t neededSpace = 2;
 
-  if (_client.space() < neededSpace) return false;
+  SEMAPHORE_TAKE(false);
+  if (_client.space() < neededSpace) { SEMAPHORE_GIVE(); return false; }
 
   _client.add(fixedHeader, 2);
   _client.send();
   _lastClientActivity = millis();
   _lastPingRequestTime = millis();
 
+  SEMAPHORE_GIVE();
   return true;
 }
 
 void AsyncMqttClient::_sendAcks() {
   uint8_t neededAckSpace = 2 + 2;
 
+  SEMAPHORE_TAKE();
   for (size_t i = 0; i < _toSendAcks.size(); i++) {
     if (_client.space() < neededAckSpace) break;
 
@@ -643,12 +653,15 @@ void AsyncMqttClient::_sendAcks() {
 
     _lastClientActivity = millis();
   }
+  SEMAPHORE_GIVE();
 }
 
 bool AsyncMqttClient::_sendDisconnect() {
   const uint8_t neededSpace = 2;
 
-  if (_client.space() < neededSpace) return false;
+  SEMAPHORE_TAKE(false);
+
+  if (_client.space() < neededSpace) { SEMAPHORE_GIVE(); return false; }
 
   char fixedHeader[2];
   fixedHeader[0] = AsyncMqttClientInternals::PacketType.DISCONNECT;
@@ -662,6 +675,7 @@ bool AsyncMqttClient::_sendDisconnect() {
 
   _disconnectFlagged = false;
 
+  SEMAPHORE_GIVE();
   return true;
 }
 
@@ -732,7 +746,9 @@ uint16_t AsyncMqttClient::subscribe(const char* topic, uint8_t qos) {
   neededSpace += 2;
   neededSpace += topicLength;
   neededSpace += 1;
-  if (_client.space() < neededSpace) return 0;
+
+  SEMAPHORE_TAKE(0);
+  if (_client.space() < neededSpace) { SEMAPHORE_GIVE(); return 0; }
 
   uint16_t packetId = _getNextPacketId();
   char packetIdBytes[2];
@@ -747,6 +763,7 @@ uint16_t AsyncMqttClient::subscribe(const char* topic, uint8_t qos) {
   _client.send();
   _lastClientActivity = millis();
 
+  SEMAPHORE_GIVE();
   return packetId;
 }
 
@@ -770,7 +787,9 @@ uint16_t AsyncMqttClient::unsubscribe(const char* topic) {
   neededSpace += 2;
   neededSpace += 2;
   neededSpace += topicLength;
-  if (_client.space() < neededSpace) return 0;
+
+  SEMAPHORE_TAKE(0);
+  if (_client.space() < neededSpace) { SEMAPHORE_GIVE(); return 0; }
 
   uint16_t packetId = _getNextPacketId();
   char packetIdBytes[2];
@@ -784,6 +803,7 @@ uint16_t AsyncMqttClient::unsubscribe(const char* topic) {
   _client.send();
   _lastClientActivity = millis();
 
+  SEMAPHORE_GIVE();
   return packetId;
 }
 
@@ -825,7 +845,9 @@ uint16_t AsyncMqttClient::publish(const char* topic, uint8_t qos, bool retain, c
   neededSpace += topicLength;
   if (qos != 0) neededSpace += 2;
   if (payload != nullptr) neededSpace += payloadLength;
-  if (_client.space() < neededSpace) return 0;
+
+  SEMAPHORE_TAKE(0);
+  if (_client.space() < neededSpace) { SEMAPHORE_GIVE(); return 0; }
 
   uint16_t packetId = 0;
   char packetIdBytes[2];
@@ -848,6 +870,7 @@ uint16_t AsyncMqttClient::publish(const char* topic, uint8_t qos, bool retain, c
   _client.send();
   _lastClientActivity = millis();
 
+  SEMAPHORE_GIVE();
   if (qos != 0) {
     return packetId;
   } else {


### PR DESCRIPTION
ESP32 has two CPU cores, it may happen that application sends publish on first CPU core, while at the same time on second CPU core publish is received and library automatically send on second CPU core ack. This ACK may send to (asynctcp) _client chunk of data in between chunks of publish sent on first CPU core.

This issue depends on traffic, with more exchanged publish messages there is higher chance to reproduce it. Also, with QOS>0 it is easier to reproduce as there are more ACKs.

I.e. ESP32 has two cores, if one core is sending ACK and other core is sending PUBLISH, those sending must be atomic operation for AsyncTCP client. Before my change each method called _client.add() multiple times to send single MQTT packets, if you do that in parallel from multiple cores you get mixed content. 