### PR TITLE
Fixed compile error (ESP32, Sloeber)

### DIFF
--- a/examples/FullyFeatured-ESP32/FullyFeatured-ESP32.ino
+++ b/examples/FullyFeatured-ESP32/FullyFeatured-ESP32.ino
@@ -62,6 +62,16 @@ void onMqttConnect(bool sessionPresent) {
   uint16_t packetIdPub2 = mqttClient.publish("test/lol", 2, true, "test 3");
   Serial.print("Publishing at QoS 2, packetId: ");
   Serial.println(packetIdPub2);
+  
+  packetIdSub = mqttClient.subscribe("Topic3/Example/Test", 2, onSpecificMqttMessage);
+  Serial.print("Subscribing at QoS 2 with specified callback, packetId: ");
+  Serial.println(packetIdSub);
+  mqttClient.publish("Topic1/Example/Test", 0, true, "Test");
+  Serial.println("Publishing \"Test\" to \"Topic1/Example/Test\" at QoS 0");
+  mqttClient.publish("Topic2/Example/Test", 0, true, "Test");
+  Serial.println("Publishing \"Test\" to \"Topic2/Example/Test\" at QoS 0");
+  mqttClient.publish("Topic3/Example/Test", 0, true, "Test");
+  Serial.println("Publishing \"Test\" to \"Topic3/Example/Test\" at QoS 0");
 }
 
 void onMqttDisconnect(AsyncMqttClientDisconnectReason reason) {
@@ -104,6 +114,23 @@ void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties 
   Serial.println(total);
 }
 
+void onSpecificMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {
+  Serial.print("Publish received for specific topic: ");
+  Serial.println(topic);
+  Serial.print("  qos: ");
+  Serial.println(properties.qos);
+  Serial.print("  dup: ");
+  Serial.println(properties.dup);
+  Serial.print("  retain: ");
+  Serial.println(properties.retain);
+  Serial.print("  len: ");
+  Serial.println(len);
+  Serial.print("  index: ");
+  Serial.println(index);
+  Serial.print("  total: ");
+  Serial.println(total);
+}
+
 void onMqttPublish(uint16_t packetId) {
   Serial.println("Publish acknowledged.");
   Serial.print("  packetId: ");
@@ -125,11 +152,12 @@ void setup() {
   mqttClient.onSubscribe(onMqttSubscribe);
   mqttClient.onUnsubscribe(onMqttUnsubscribe);
   mqttClient.onMessage(onMqttMessage);
+  mqttClient.onMessage(onSpecificMqttMessage, "Topic1/#");               // Optional - Overloaded example
+  mqttClient.onFilteredMessage(onSpecificMqttMessage, "Topic2/+/Test");  // Optional - Method for verbose reading
   mqttClient.onPublish(onMqttPublish);
   mqttClient.setServer(MQTT_HOST, MQTT_PORT);
 
   connectToWifi();
 }
 
-void loop() {
-}
+void loop() {}

--- a/examples/FullyFeatured-ESP8266/FullyFeatured-ESP8266.ino
+++ b/examples/FullyFeatured-ESP8266/FullyFeatured-ESP8266.ino
@@ -40,6 +40,7 @@ void onMqttConnect(bool sessionPresent) {
   Serial.println("Connected to MQTT.");
   Serial.print("Session present: ");
   Serial.println(sessionPresent);
+
   uint16_t packetIdSub = mqttClient.subscribe("test/lol", 2);
   Serial.print("Subscribing at QoS 2, packetId: ");
   Serial.println(packetIdSub);
@@ -51,6 +52,16 @@ void onMqttConnect(bool sessionPresent) {
   uint16_t packetIdPub2 = mqttClient.publish("test/lol", 2, true, "test 3");
   Serial.print("Publishing at QoS 2, packetId: ");
   Serial.println(packetIdPub2);
+
+  packetIdSub = mqttClient.subscribe("Topic3/Example/Test", 2, onSpecificMqttMessage);
+  Serial.print("Subscribing at QoS 2 with specified callback, packetId: ");
+  Serial.println(packetIdSub);
+  mqttClient.publish("Topic1/Example/Test", 0, true, "Test");
+  Serial.println("Publishing \"Test\" to \"Topic1/Example/Test\" at QoS 0");
+  mqttClient.publish("Topic2/Example/Test", 0, true, "Test");
+  Serial.println("Publishing \"Test\" to \"Topic2/Example/Test\" at QoS 0");
+  mqttClient.publish("Topic3/Example/Test", 0, true, "Test");
+  Serial.println("Publishing \"Test\" to \"Topic3/Example/Test\" at QoS 0");
 }
 
 void onMqttDisconnect(AsyncMqttClientDisconnectReason reason) {
@@ -93,6 +104,23 @@ void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties 
   Serial.println(total);
 }
 
+void onSpecificMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {
+  Serial.print("Publish received for specific topic: ");
+  Serial.println(topic);
+  Serial.print("  qos: ");
+  Serial.println(properties.qos);
+  Serial.print("  dup: ");
+  Serial.println(properties.dup);
+  Serial.print("  retain: ");
+  Serial.println(properties.retain);
+  Serial.print("  len: ");
+  Serial.println(len);
+  Serial.print("  index: ");
+  Serial.println(index);
+  Serial.print("  total: ");
+  Serial.println(total);
+}
+
 void onMqttPublish(uint16_t packetId) {
   Serial.println("Publish acknowledged.");
   Serial.print("  packetId: ");
@@ -112,11 +140,12 @@ void setup() {
   mqttClient.onSubscribe(onMqttSubscribe);
   mqttClient.onUnsubscribe(onMqttUnsubscribe);
   mqttClient.onMessage(onMqttMessage);
+  mqttClient.onMessage(onSpecificMqttMessage, "Topic1/#");               // Optional - Overloaded example
+  mqttClient.onFilteredMessage(onSpecificMqttMessage, "Topic2/+/Test");  // Optional - Method for verbose reading
   mqttClient.onPublish(onMqttPublish);
   mqttClient.setServer(MQTT_HOST, MQTT_PORT);
 
   connectToWifi();
 }
 
-void loop() {
-}
+void loop() {}

--- a/keywords.txt
+++ b/keywords.txt
@@ -25,6 +25,7 @@ onDisconnect	KEYWORD2
 onSubscribe	KEYWORD2
 onUnsubscribe	KEYWORD2
 onMessage	KEYWORD2
+onFilteredMessage	KEYWORD2 
 onPublish	KEYWORD2
 
 connected	KEYWORD2

--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "https://github.com/marvinroger/async-mqtt-client.git"
   },
-  "version": "0.8.2",
+  "version": "0.8.2x",
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32"],
   "dependencies": [

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AsyncMqttClient
-version=0.8.2
+version=0.8.2x
 author=Marvin ROGER
 maintainer=Marvin ROGER
 sentence=An Arduino for ESP8266 and ESP32 asynchronous MQTT client implementation

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -830,8 +830,10 @@ uint16_t AsyncMqttClient::subscribe(const char* topic, uint8_t qos) {
 }
 
 uint16_t AsyncMqttClient::subscribe(const char* topic, uint8_t qos, AsyncMqttClientInternals::OnMessageUserCallback callback) {
+  if (!_connected) return 0;
   onFilteredMessage(callback, topic);
   subscribe(topic, qos);
+  return 0;
 }
 
 uint16_t AsyncMqttClient::unsubscribe(const char* topic) {

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -37,7 +37,7 @@ AsyncMqttClient::AsyncMqttClient()
   _client.onPoll([](void* obj, AsyncClient* c) { (static_cast<AsyncMqttClient*>(obj))->_onPoll(c); }, this);
 
 #ifdef ESP32
-  sprintf(_generatedClientId, "esp32%06x", ESP.getEfuseMac());
+  sprintf(_generatedClientId, "esp32%06llx", ESP.getEfuseMac());
   _xSemaphore = xSemaphoreCreateMutex();
 #elif defined(ESP8266)
   sprintf(_generatedClientId, "esp8266%06x", ESP.getChipId());

--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -68,20 +68,25 @@ class AsyncMqttClient {
   AsyncMqttClient& onDisconnect(AsyncMqttClientInternals::OnDisconnectUserCallback callback);
   AsyncMqttClient& onSubscribe(AsyncMqttClientInternals::OnSubscribeUserCallback callback);
   AsyncMqttClient& onUnsubscribe(AsyncMqttClientInternals::OnUnsubscribeUserCallback callback);
-  AsyncMqttClient& onMessage(AsyncMqttClientInternals::OnMessageUserCallback callback);
+  AsyncMqttClient& onMessage(AsyncMqttClientInternals::OnMessageUserCallback callback, const char* _userTopic = "#");
+  AsyncMqttClient& onFilteredMessage(AsyncMqttClientInternals::OnMessageUserCallback callback, const char* _userTopic);
   AsyncMqttClient& onPublish(AsyncMqttClientInternals::OnPublishUserCallback callback);
 
   bool connected() const;
   void connect();
   void disconnect(bool force = false);
   uint16_t subscribe(const char* topic, uint8_t qos);
+  uint16_t subscribe(const char* topic, uint8_t qos, AsyncMqttClientInternals::OnMessageUserCallback callback);
   uint16_t unsubscribe(const char* topic);
   uint16_t publish(const char* topic, uint8_t qos, bool retain, const char* payload = nullptr, size_t length = 0, bool dup = false, uint16_t message_id = 0);
+
+  const char* getClientId();
 
  private:
   AsyncClient _client;
 
   bool _connected;
+  bool _lockMutiConnections;
   bool _connectPacketNotEnoughSpace;
   bool _disconnectFlagged;
   bool _tlsBadFingerprint;
@@ -89,7 +94,7 @@ class AsyncMqttClient {
   uint32_t _lastServerActivity;
   uint32_t _lastPingRequestTime;
 
-  char _generatedClientId[13 + 1];  // esp8266abc123
+  char _generatedClientId[18 + 1];  // esp8266-abc123 and esp32-abcdef123456
   IPAddress _ip;
   const char* _host;
   bool _useIp;
@@ -116,7 +121,7 @@ class AsyncMqttClient {
   std::vector<AsyncMqttClientInternals::OnDisconnectUserCallback> _onDisconnectUserCallbacks;
   std::vector<AsyncMqttClientInternals::OnSubscribeUserCallback> _onSubscribeUserCallbacks;
   std::vector<AsyncMqttClientInternals::OnUnsubscribeUserCallback> _onUnsubscribeUserCallbacks;
-  std::vector<AsyncMqttClientInternals::OnMessageUserCallback> _onMessageUserCallbacks;
+  std::vector<AsyncMqttClientInternals::onFilteredMessageUserCallback> _onMessageUserCallbacks;
   std::vector<AsyncMqttClientInternals::OnPublishUserCallback> _onPublishUserCallbacks;
 
   AsyncMqttClientInternals::ParsingInformation _parsingInformation;

--- a/src/AsyncMqttClient/Callbacks.hpp
+++ b/src/AsyncMqttClient/Callbacks.hpp
@@ -12,6 +12,8 @@ typedef std::function<void(AsyncMqttClientDisconnectReason reason)> OnDisconnect
 typedef std::function<void(uint16_t packetId, uint8_t qos)> OnSubscribeUserCallback;
 typedef std::function<void(uint16_t packetId)> OnUnsubscribeUserCallback;
 typedef std::function<void(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total)> OnMessageUserCallback;
+// typedef std::pair<std::string, std::function<void(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total)>> onFilteredMessageUserCallback;
+typedef std::pair<char*, std::function<void(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total)>> onFilteredMessageUserCallback;
 typedef std::function<void(uint16_t packetId)> OnPublishUserCallback;
 
 // internal callbacks

--- a/src/AsyncMqttClient/Packets/PublishPacket.cpp
+++ b/src/AsyncMqttClient/Packets/PublishPacket.cpp
@@ -16,7 +16,8 @@ PublishPacket::PublishPacket(ParsingInformation* parsingInformation, OnMessageIn
 , _packetIdMsb(0)
 , _packetId(0)
 , _payloadLength(0)
-, _payloadBytesRead(0) {
+, _payloadBytesRead(0)
+, _ptempbuff(0) {
     _dup = _parsingInformation->packetFlags & HeaderFlag.PUBLISH_DUP;
     _retain = _parsingInformation->packetFlags & HeaderFlag.PUBLISH_RETAIN;
     char qosMasked = _parsingInformation->packetFlags & 0x06;
@@ -78,14 +79,36 @@ void PublishPacket::_preparePayloadHandling(uint32_t payloadLength) {
 
 void PublishPacket::parsePayload(char* data, size_t len, size_t* currentBytePosition) {
   size_t remainToRead = len - (*currentBytePosition);
-  if (_payloadBytesRead + remainToRead > _payloadLength) remainToRead = _payloadLength - _payloadBytesRead;
-
-  if (!_ignore) _dataCallback(_parsingInformation->topicBuffer, data + (*currentBytePosition), _qos, _dup, _retain, remainToRead, _payloadBytesRead, _payloadLength, _packetId);
+  if (_payloadBytesRead + remainToRead > _payloadLength)
+    remainToRead = _payloadLength - _payloadBytesRead;
+  if (!_ignore) {
+    if (remainToRead < _payloadLength) {
+      if (!_ptempbuff) {
+        _ptempbuff = new char[_payloadLength + 1];
+        if (_ptempbuff == nullptr) {
+          _ignore = true;
+          return;
+        }
+        memset(_ptempbuff, 0, _payloadLength + 1);
+        memcpy(&_ptempbuff[_payloadBytesRead], &data[(*currentBytePosition)], remainToRead);
+      } else {
+        memcpy(&_ptempbuff[_payloadBytesRead], &data[(*currentBytePosition)], remainToRead);
+        if ((_payloadBytesRead + remainToRead) == _payloadLength) {
+          _dataCallback(_parsingInformation->topicBuffer, _ptempbuff, _qos, _dup, _retain, _payloadLength, 0, _payloadLength, _packetId);
+          delete[] _ptempbuff;
+          _ptempbuff = NULL;
+        }
+      }
+    } else {
+      _dataCallback(_parsingInformation->topicBuffer, &data[(*currentBytePosition)], _qos, _dup, _retain, remainToRead, _payloadBytesRead, _payloadLength, _packetId);
+    }
+  }
   _payloadBytesRead += remainToRead;
   (*currentBytePosition) += remainToRead;
 
   if (_payloadBytesRead == _payloadLength) {
     _parsingInformation->bufferState = BufferState::NONE;
-    if (!_ignore) _completeCallback(_packetId, _qos);
+    if (!_ignore)
+      _completeCallback(_packetId, _qos);
   }
 }

--- a/src/AsyncMqttClient/Packets/PublishPacket.hpp
+++ b/src/AsyncMqttClient/Packets/PublishPacket.hpp
@@ -34,5 +34,6 @@ class PublishPacket : public Packet {
   uint16_t _packetId;
   uint32_t _payloadLength;
   uint32_t _payloadBytesRead;
+  char*    _ptempbuff;
 };
 }  // namespace AsyncMqttClientInternals


### PR DESCRIPTION
Failed compilation due to incorrect sprintf format specifier when generating client ID for ESP32. Was %06x, should be %06llx since ESP.getEfuseMac() returns long long (64-bit).