### PR TITLE
Fixes #105 . Mqtt half open connections. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /config.json
+.vscode/

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -451,6 +451,10 @@ void AsyncMqttClient::_onPoll(AsyncClient* client) {
   if (_lastPingRequestTime != 0 && (millis() - _lastPingRequestTime) >= (_keepAlive * 1000 * 2)) {
     disconnect();
     return;
+  }
+  else if(millis() - _lastServerActivity >= (_keepAlive * 1000 * 2)) {
+    disconnect();
+    return;
   // send ping to ensure the server will receive at least one message inside keepalive window
   } else if (_lastPingRequestTime == 0 && (millis() - _lastClientActivity) >= (_keepAlive * 1000 * 0.7)) {
     _sendPing();

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -449,11 +449,11 @@ void AsyncMqttClient::_onPoll(AsyncClient* client) {
 
   // if there is too much time the client has sent a ping request without a response, disconnect client to avoid half open connections
   if (_lastPingRequestTime != 0 && (millis() - _lastPingRequestTime) >= (_keepAlive * 1000 * 2)) {
-    disconnect();
+    disconnect(true);
     return;
   }
   else if(millis() - _lastServerActivity >= (_keepAlive * 1000 * 2)) {
-    disconnect();
+    disconnect(true);
     return;
   // send ping to ensure the server will receive at least one message inside keepalive window
   } else if (_lastPingRequestTime == 0 && (millis() - _lastClientActivity) >= (_keepAlive * 1000 * 0.7)) {
@@ -664,7 +664,11 @@ bool AsyncMqttClient::_sendDisconnect() {
 
   SEMAPHORE_TAKE(false);
 
-  if (_client.space() < neededSpace) { SEMAPHORE_GIVE(); return false; }
+  if (_client.space() < neededSpace) { 
+    SEMAPHORE_GIVE();
+    _client.close(true);
+    return false; 
+  }
 
   char fixedHeader[2];
   fixedHeader[0] = AsyncMqttClientInternals::PacketType.DISCONNECT;

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -667,6 +667,7 @@ bool AsyncMqttClient::_sendDisconnect() {
   if (_client.space() < neededSpace) { 
     SEMAPHORE_GIVE();
     _client.close(true);
+    _clear();
     return false; 
   }
 
@@ -722,6 +723,7 @@ void AsyncMqttClient::disconnect(bool force) {
 
   if (force) {
     _client.close(true);
+    _clear();
   } else {
     _disconnectFlagged = true;
     _sendDisconnect();


### PR DESCRIPTION
Assuming that if server is still connected, it would send at least one packet within keepalive*2 time. If it is not received, it means we have lost the connection. We should trigger a force disconnect. 
Edit: Mentioning #105 