### PR TITLE
Add message filtering ability

### DIFF
--- a/examples/FullyFeatured-ESP32/FullyFeatured-ESP32.ino
+++ b/examples/FullyFeatured-ESP32/FullyFeatured-ESP32.ino
@@ -62,6 +62,16 @@ void onMqttConnect(bool sessionPresent) {
   uint16_t packetIdPub2 = mqttClient.publish("test/lol", 2, true, "test 3");
   Serial.print("Publishing at QoS 2, packetId: ");
   Serial.println(packetIdPub2);
+  
+  packetIdSub = mqttClient.subscribe("Topic3/Example/Test", 2, onSpecificMqttMessage);
+  Serial.print("Subscribing at QoS 2 with specified callback, packetId: ");
+  Serial.println(packetIdSub);
+  mqttClient.publish("Topic1/Example/Test", 0, true, "Test");
+  Serial.println("Publishing \"Test\" to \"Topic1/Example/Test\" at QoS 0");
+  mqttClient.publish("Topic2/Example/Test", 0, true, "Test");
+  Serial.println("Publishing \"Test\" to \"Topic2/Example/Test\" at QoS 0");
+  mqttClient.publish("Topic3/Example/Test", 0, true, "Test");
+  Serial.println("Publishing \"Test\" to \"Topic3/Example/Test\" at QoS 0");
 }
 
 void onMqttDisconnect(AsyncMqttClientDisconnectReason reason) {
@@ -104,6 +114,23 @@ void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties 
   Serial.println(total);
 }
 
+void onSpecificMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {
+  Serial.print("Publish received for specific topic: ");
+  Serial.println(topic);
+  Serial.print("  qos: ");
+  Serial.println(properties.qos);
+  Serial.print("  dup: ");
+  Serial.println(properties.dup);
+  Serial.print("  retain: ");
+  Serial.println(properties.retain);
+  Serial.print("  len: ");
+  Serial.println(len);
+  Serial.print("  index: ");
+  Serial.println(index);
+  Serial.print("  total: ");
+  Serial.println(total);
+}
+
 void onMqttPublish(uint16_t packetId) {
   Serial.println("Publish acknowledged.");
   Serial.print("  packetId: ");
@@ -125,11 +152,12 @@ void setup() {
   mqttClient.onSubscribe(onMqttSubscribe);
   mqttClient.onUnsubscribe(onMqttUnsubscribe);
   mqttClient.onMessage(onMqttMessage);
+  mqttClient.onMessage(onSpecificMqttMessage, "Topic1/#");               // Optional - Overloaded example
+  mqttClient.onFilteredMessage(onSpecificMqttMessage, "Topic2/+/Test");  // Optional - Method for verbose reading
   mqttClient.onPublish(onMqttPublish);
   mqttClient.setServer(MQTT_HOST, MQTT_PORT);
 
   connectToWifi();
 }
 
-void loop() {
-}
+void loop() {}

--- a/examples/FullyFeatured-ESP8266/FullyFeatured-ESP8266.ino
+++ b/examples/FullyFeatured-ESP8266/FullyFeatured-ESP8266.ino
@@ -40,6 +40,7 @@ void onMqttConnect(bool sessionPresent) {
   Serial.println("Connected to MQTT.");
   Serial.print("Session present: ");
   Serial.println(sessionPresent);
+
   uint16_t packetIdSub = mqttClient.subscribe("test/lol", 2);
   Serial.print("Subscribing at QoS 2, packetId: ");
   Serial.println(packetIdSub);
@@ -51,6 +52,16 @@ void onMqttConnect(bool sessionPresent) {
   uint16_t packetIdPub2 = mqttClient.publish("test/lol", 2, true, "test 3");
   Serial.print("Publishing at QoS 2, packetId: ");
   Serial.println(packetIdPub2);
+
+  packetIdSub = mqttClient.subscribe("Topic3/Example/Test", 2, onSpecificMqttMessage);
+  Serial.print("Subscribing at QoS 2 with specified callback, packetId: ");
+  Serial.println(packetIdSub);
+  mqttClient.publish("Topic1/Example/Test", 0, true, "Test");
+  Serial.println("Publishing \"Test\" to \"Topic1/Example/Test\" at QoS 0");
+  mqttClient.publish("Topic2/Example/Test", 0, true, "Test");
+  Serial.println("Publishing \"Test\" to \"Topic2/Example/Test\" at QoS 0");
+  mqttClient.publish("Topic3/Example/Test", 0, true, "Test");
+  Serial.println("Publishing \"Test\" to \"Topic3/Example/Test\" at QoS 0");
 }
 
 void onMqttDisconnect(AsyncMqttClientDisconnectReason reason) {
@@ -93,6 +104,23 @@ void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties 
   Serial.println(total);
 }
 
+void onSpecificMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {
+  Serial.print("Publish received for specific topic: ");
+  Serial.println(topic);
+  Serial.print("  qos: ");
+  Serial.println(properties.qos);
+  Serial.print("  dup: ");
+  Serial.println(properties.dup);
+  Serial.print("  retain: ");
+  Serial.println(properties.retain);
+  Serial.print("  len: ");
+  Serial.println(len);
+  Serial.print("  index: ");
+  Serial.println(index);
+  Serial.print("  total: ");
+  Serial.println(total);
+}
+
 void onMqttPublish(uint16_t packetId) {
   Serial.println("Publish acknowledged.");
   Serial.print("  packetId: ");
@@ -112,11 +140,12 @@ void setup() {
   mqttClient.onSubscribe(onMqttSubscribe);
   mqttClient.onUnsubscribe(onMqttUnsubscribe);
   mqttClient.onMessage(onMqttMessage);
+  mqttClient.onMessage(onSpecificMqttMessage, "Topic1/#");               // Optional - Overloaded example
+  mqttClient.onFilteredMessage(onSpecificMqttMessage, "Topic2/+/Test");  // Optional - Method for verbose reading
   mqttClient.onPublish(onMqttPublish);
   mqttClient.setServer(MQTT_HOST, MQTT_PORT);
 
   connectToWifi();
 }
 
-void loop() {
-}
+void loop() {}

--- a/keywords.txt
+++ b/keywords.txt
@@ -25,6 +25,7 @@ onDisconnect	KEYWORD2
 onSubscribe	KEYWORD2
 onUnsubscribe	KEYWORD2
 onMessage	KEYWORD2
+onFilteredMessage	KEYWORD2 
 onPublish	KEYWORD2
 
 connected	KEYWORD2

--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -68,13 +68,15 @@ class AsyncMqttClient {
   AsyncMqttClient& onDisconnect(AsyncMqttClientInternals::OnDisconnectUserCallback callback);
   AsyncMqttClient& onSubscribe(AsyncMqttClientInternals::OnSubscribeUserCallback callback);
   AsyncMqttClient& onUnsubscribe(AsyncMqttClientInternals::OnUnsubscribeUserCallback callback);
-  AsyncMqttClient& onMessage(AsyncMqttClientInternals::OnMessageUserCallback callback);
+  AsyncMqttClient& onMessage(AsyncMqttClientInternals::OnMessageUserCallback callback, const char* _userTopic = "#");
+  AsyncMqttClient& onFilteredMessage(AsyncMqttClientInternals::OnMessageUserCallback callback, const char* _userTopic);
   AsyncMqttClient& onPublish(AsyncMqttClientInternals::OnPublishUserCallback callback);
 
   bool connected() const;
   void connect();
   void disconnect(bool force = false);
   uint16_t subscribe(const char* topic, uint8_t qos);
+  uint16_t subscribe(const char* topic, uint8_t qos, AsyncMqttClientInternals::OnMessageUserCallback callback);
   uint16_t unsubscribe(const char* topic);
   uint16_t publish(const char* topic, uint8_t qos, bool retain, const char* payload = nullptr, size_t length = 0, bool dup = false, uint16_t message_id = 0);
 
@@ -116,7 +118,7 @@ class AsyncMqttClient {
   std::vector<AsyncMqttClientInternals::OnDisconnectUserCallback> _onDisconnectUserCallbacks;
   std::vector<AsyncMqttClientInternals::OnSubscribeUserCallback> _onSubscribeUserCallbacks;
   std::vector<AsyncMqttClientInternals::OnUnsubscribeUserCallback> _onUnsubscribeUserCallbacks;
-  std::vector<AsyncMqttClientInternals::OnMessageUserCallback> _onMessageUserCallbacks;
+  std::vector<AsyncMqttClientInternals::onFilteredMessageUserCallback> _onMessageUserCallbacks;
   std::vector<AsyncMqttClientInternals::OnPublishUserCallback> _onPublishUserCallbacks;
 
   AsyncMqttClientInternals::ParsingInformation _parsingInformation;

--- a/src/AsyncMqttClient/Callbacks.hpp
+++ b/src/AsyncMqttClient/Callbacks.hpp
@@ -12,6 +12,8 @@ typedef std::function<void(AsyncMqttClientDisconnectReason reason)> OnDisconnect
 typedef std::function<void(uint16_t packetId, uint8_t qos)> OnSubscribeUserCallback;
 typedef std::function<void(uint16_t packetId)> OnUnsubscribeUserCallback;
 typedef std::function<void(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total)> OnMessageUserCallback;
+// typedef std::pair<std::string, std::function<void(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total)>> onFilteredMessageUserCallback;
+typedef std::pair<char*, std::function<void(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total)>> onFilteredMessageUserCallback;
 typedef std::function<void(uint16_t packetId)> OnPublishUserCallback;
 
 // internal callbacks


### PR DESCRIPTION
Been using this library for a while and absolutely love it. The async nature is second to none above similar libraries. However I find myself writing boiler plate every time I set up a new project to filter incoming messages to achieve the correct action in the onMessage() callback.

To help improve on the library, I added the ability to filter the topic of an incoming message in the _onMessage() function when looping through each of the added callbacks from the user. This is achieved by supplying a chosen topic when adding a callback with onMessage() and a new method onFilteredMessage(). These achieve the same outcome, but one is easier to follow when reading code.

`AsyncMqttClient& AsyncMqttClient::onMessage(AsyncMqttClientInternals::OnMessageUserCallback callback, const char* _userTopic = "#")'
'AsyncMqttClient& AsyncMqttClient::onFilteredMessage(AsyncMqttClientInternals::OnMessageUserCallback callback, const char* _userTopic)`

I also added a shortcut for this by overloading subscribe(). By supplying a callback when adding a subscription, the callback will be added to the vector called by _onMessage() actually removing the need to supply a callback using onMessage(). 

`uint16_t AsyncMqttClient::subscribe(const char* topic, uint8_t qos, AsyncMqttClientInternals::OnMessageUserCallback callback)`

I think with these two methods and a little documentation on how to use them would make using the library a little more straightforward and far more efficient for new users when subscribing to more than one topic needing more than one callback. It will also reduce a bunch of boilerplate in a fair few of my projects and I hope a few from others.

I have tried to keep to the same formatting and style for easy integration, and have also updated all supporting files such as the examples and keywords.