### PR TITLE
Fix compile issues with ESPAsyncTCP and PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -18,7 +18,7 @@
   "dependencies": [
     {
       "name": "ESPAsyncTCP",
-      "version": "^1.1.0",
+      "version": "1.2.0",
       "platforms": "espressif8266"
     },
     {


### PR DESCRIPTION
The library doesn't compile with the newer ESPAsyncTCP versions (1.2.1 and up). That causes issues with PlatformIO and requires manual changes in the library.json files as a workaround.