### PR TITLE
Improving stability

### DIFF
--- a/library.json
+++ b/library.json
@@ -18,12 +18,10 @@
   "dependencies": [
     {
       "name": "ESPAsyncTCP",
-      "version": "1.2.0",
       "platforms": "espressif8266"
     },
     {
       "name": "AsyncTCP",
-      "version": "^1.0.0",
       "platforms": "espressif32"
     }
   ]

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -44,7 +44,6 @@ AsyncMqttClient::AsyncMqttClient()
   sprintf(_generatedClientId, "esp8266-%06x", ESP.getChipId());
 #endif
   _clientId = _generatedClientId;
-
   setMaxTopicLength(128);
 }
 

--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -82,7 +82,7 @@ class AsyncMqttClient {
 
  private:
   AsyncClient _client;
-
+  bool _lockMutiConnections;
   bool _connected;
   bool _connectPacketNotEnoughSpace;
   bool _disconnectOnPoll;

--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -82,8 +82,8 @@ class AsyncMqttClient {
 
  private:
   AsyncClient _client;
-  bool _lockMutiConnections;
   bool _connected;
+  bool _lockMutiConnections;
   bool _connectPacketNotEnoughSpace;
   bool _disconnectOnPoll;
   bool _tlsBadFingerprint;


### PR DESCRIPTION
Problem: When repeatedly calling "AsyncMqttClient::connect()" method, while the connection has not yet been established,
at the level of the "ESP Async TCP" library or at the level of Espressif SDK,
many "half-dead" objects are created that are referenced by the same callback functions.
These objects are not participating in the data exchange, however,
they periodically call these callback functions, which leads to malfunctions.

Solution: Adding a blocking flag "AsyncMqttClient::_lockMultyConnections" to the "Async MQTT Client" library,
which prevents consequences of multiple calls to the methods "AsyncMqttClient::connect()" and "AsyncMqttClient::disconnect()"