### PR TITLE
simplify + bugfix keeping session data

### DIFF
--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -343,10 +343,8 @@ void AsyncMqttClient::_onPoll() {
   // send ping to ensure the server will receive at least one message inside keepalive window
   if (_state == CONNECTED && _lastPingRequestTime == 0 && (millis() - _lastClientActivity) >= (_keepAlive * 1000 * 0.7)) {
     _sendPing();
-
   // send ping to verify if the server is still there (ensure this is not a half connection)
   } else if (_state == CONNECTED && _lastPingRequestTime == 0 && (millis() - _lastServerActivity) >= (_keepAlive * 1000 * 0.7)) {
-    
     _sendPing();
   }
   _handleQueue();
@@ -487,7 +485,6 @@ void AsyncMqttClient::_clearQueue(bool keepSessionData) {
         delete packet;
         packet = next;
       }
-    
     /* Delete everything when not keeping session data
      */
     } else {

--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -85,12 +85,10 @@ class AsyncMqttClient {
   const char* getClientId() const;
 
  private:
-  AsyncClient* _client;  // AsyncClient has to be destroyed created because of bug https://github.com/me-no-dev/ESPAsyncTCP/issues/160
-  AsyncMqttClientInternals::OutPacket* _firstPacket;
-  AsyncMqttClientInternals::OutPacket* _lastPacket;
-  AsyncMqttClientInternals::OutPacket* _sendHead;
+  AsyncClient _client;
+  AsyncMqttClientInternals::OutPacket* _head;
+  AsyncMqttClientInternals::OutPacket* _tail;
   size_t _sent;
-  size_t _acked;
   enum {
     CONNECTING,
     CONNECTED,

--- a/src/AsyncMqttClient/Callbacks.hpp
+++ b/src/AsyncMqttClient/Callbacks.hpp
@@ -4,6 +4,7 @@
 
 #include "DisconnectReasons.hpp"
 #include "MessageProperties.hpp"
+#include "Errors.hpp"
 
 namespace AsyncMqttClientInternals {
 // user callbacks
@@ -13,6 +14,7 @@ typedef std::function<void(uint16_t packetId, uint8_t qos)> OnSubscribeUserCallb
 typedef std::function<void(uint16_t packetId)> OnUnsubscribeUserCallback;
 typedef std::function<void(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total)> OnMessageUserCallback;
 typedef std::function<void(uint16_t packetId)> OnPublishUserCallback;
+typedef std::function<void(uint16_t packetId, AsyncMqttClientError error)> OnErrorUserCallback;
 
 // internal callbacks
 typedef std::function<void(bool sessionPresent, uint8_t connectReturnCode)> OnConnAckInternalCallback;

--- a/src/AsyncMqttClient/Errors.hpp
+++ b/src/AsyncMqttClient/Errors.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+enum class AsyncMqttClientError : uint8_t {
+  MAX_RETRIES = 0,
+  OUT_OF_MEMORY = 1
+};

--- a/src/AsyncMqttClient/Packets/Out/Disconn.cpp
+++ b/src/AsyncMqttClient/Packets/Out/Disconn.cpp
@@ -7,7 +7,6 @@ DisconnOutPacket::DisconnOutPacket() {
   _data[0] = _data[0] << 4;
   _data[0] = _data[0] | AsyncMqttClientInternals::HeaderFlag.DISCONNECT_RESERVED;
   _data[1] = 0;
-  _released = true;
 }
 
 const uint8_t* DisconnOutPacket::data(size_t index) const {

--- a/src/AsyncMqttClient/Packets/Out/OutPacket.cpp
+++ b/src/AsyncMqttClient/Packets/Out/OutPacket.cpp
@@ -3,8 +3,10 @@
 using AsyncMqttClientInternals::OutPacket;
 
 OutPacket::OutPacket()
-: _next(nullptr)
-, _released(false) {}
+: next(nullptr)
+, timeout(0)
+, noTries(0)
+, _released(true) {}
 
 OutPacket::~OutPacket() {}
 
@@ -29,14 +31,6 @@ uint8_t OutPacket::qos() const {
 
 void OutPacket::release() {
   _released = true;
-}
-
-OutPacket* OutPacket::getNext() const {
-  return _next;
-}
-
-void OutPacket::setNext(OutPacket* packet) {
-  _next = packet;
 }
 
 uint16_t OutPacket::_packetId = 0;

--- a/src/AsyncMqttClient/Packets/Out/OutPacket.hpp
+++ b/src/AsyncMqttClient/Packets/Out/OutPacket.hpp
@@ -19,12 +19,13 @@ class OutPacket {
   uint8_t qos() const;
   void release();
 
-  OutPacket* getNext() const;
-  void setNext(OutPacket* packet);
+ public:
+  OutPacket* next;
+  uint32_t timeout;
+  uint8_t noTries;
 
  protected:
   static uint16_t _getNextPacketId();
-  OutPacket* _next;
   bool _released;
 
  private:

--- a/src/AsyncMqttClient/Packets/Out/PingReq.cpp
+++ b/src/AsyncMqttClient/Packets/Out/PingReq.cpp
@@ -7,7 +7,6 @@ PingReqOutPacket::PingReqOutPacket() {
   _data[0] = _data[0] << 4;
   _data[0] = _data[0] | AsyncMqttClientInternals::HeaderFlag.PINGREQ_RESERVED;
   _data[1] = 0;
-  _released = true;
 }
 
 const uint8_t* PingReqOutPacket::data(size_t index) const {

--- a/src/AsyncMqttClient/Packets/Out/Publish.cpp
+++ b/src/AsyncMqttClient/Packets/Out/Publish.cpp
@@ -2,7 +2,9 @@
 
 using AsyncMqttClientInternals::PublishOutPacket;
 
-PublishOutPacket::PublishOutPacket(const char* topic, uint8_t qos, bool retain, const char* payload, size_t length) {
+PublishOutPacket::PublishOutPacket(const char* topic, uint8_t qos, bool retain, const char* payload, size_t length)
+: timeout(0)
+, noTries(0) {
   char fixedHeader[5];
   fixedHeader[0] = AsyncMqttClientInternals::PacketType.PUBLISH;
   fixedHeader[0] = fixedHeader[0] << 4;
@@ -51,8 +53,7 @@ PublishOutPacket::PublishOutPacket(const char* topic, uint8_t qos, bool retain, 
   _data.insert(_data.end(), topic, topic + topicLength);
   if (qos != 0) {
     _data.insert(_data.end(), packetIdBytes, packetIdBytes + 2);
-  } else {
-    _released = true;
+    _released = false;
   }
   if (payload != nullptr) _data.insert(_data.end(), payload, payload + payloadLength);
 }

--- a/src/AsyncMqttClient/Packets/Out/Publish.hpp
+++ b/src/AsyncMqttClient/Packets/Out/Publish.hpp
@@ -18,6 +18,10 @@ class PublishOutPacket : public OutPacket {
 
   void setDup();  // you cannot unset dup
 
+ public:
+  uint32_t timeout;
+  uint8_t noTries;
+
  private:
   std::vector<uint8_t> _data;
   uint16_t _packetId;

--- a/src/AsyncMqttClient/Packets/Out/Subscribe.cpp
+++ b/src/AsyncMqttClient/Packets/Out/Subscribe.cpp
@@ -37,6 +37,7 @@ SubscribeOutPacket::SubscribeOutPacket(const char* topic, uint8_t qos) {
   _data.insert(_data.end(), topicLengthBytes, topicLengthBytes + 2);
   _data.insert(_data.end(), topic, topic + topicLength);
   _data.push_back(qosByte[0]);
+  _released = false;
 }
 
 const uint8_t* SubscribeOutPacket::data(size_t index) const {

--- a/src/AsyncMqttClient/Packets/Out/Unsubscribe.cpp
+++ b/src/AsyncMqttClient/Packets/Out/Unsubscribe.cpp
@@ -30,6 +30,7 @@ UnsubscribeOutPacket::UnsubscribeOutPacket(const char* topic) {
   _data.insert(_data.end(), packetIdBytes, packetIdBytes + 2);
   _data.insert(_data.end(), topicLengthBytes, topicLengthBytes + 2);
   _data.insert(_data.end(), topic, topic + topicLength);
+  _released = false;
 }
 
 const uint8_t* UnsubscribeOutPacket::data(size_t index) const {


### PR DESCRIPTION
LWIP always adds the COPY flag on ESP8266 and ESP32 so there is no need for this lib to keep data until acked.
This also means we don't suffer from the "ack handler doesn't fire"-bug in ESPAsyncTCP and can have the tcp-client as member instead of as pointer.