### PR TITLE
Return disconnect reason to user

### DIFF
--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -84,9 +84,8 @@ class AsyncMqttClient {
   AsyncClient _client;
 
   bool _connected;
-  bool _connectPacketNotEnoughSpace;
   bool _disconnectOnPoll;
-  bool _tlsBadFingerprint;
+  AsyncMqttClientDisconnectReason _disconnectReason;
   uint32_t _lastClientActivity;
   uint32_t _lastServerActivity;
   uint32_t _lastPingRequestTime;

--- a/src/AsyncMqttClient/DisconnectReasons.hpp
+++ b/src/AsyncMqttClient/DisconnectReasons.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-enum class AsyncMqttClientDisconnectReason : int8_t {
+enum class AsyncMqttClientDisconnectReason : uint8_t {
   TCP_DISCONNECTED = 0,
 
   MQTT_UNACCEPTABLE_PROTOCOL_VERSION = 1,


### PR DESCRIPTION
This commit provides the API's inherent functionality to return a connection code on connection error in the onDisconnect function. Thanks for idea @bertmelis . The code is tested and ready to be merged.