### PR TITLE
According to https://github.com/marvinroger/async-mqtt-client/issues/…

### DIFF
--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -407,7 +407,6 @@ void AsyncMqttClient::_handleQueue() {
       (void)realSent;
       _client.send();
       _lastClientActivity = millis();
-      _lastPingRequestTime = 0;
       #if ASYNC_TCP_SSL_ENABLED
       log_i("snd #%u: (tls: %u) %u/%u", _head->packetType(), realSent, _sent, _head->size());
       #else


### PR DESCRIPTION
…281#issuecomment-1112897839 - remove clearing the variable - seems to be working, especially on slow connections like GSM.