### PR TITLE
Advance _sent by bytes actually written, not bytes requested

### DIFF
--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -403,8 +403,18 @@ void AsyncMqttClient::_handleQueue() {
       // So we calculate the amount to be written ourselves.
       size_t willSend = std::min(_head->size() - _sent, _client.space());
       size_t realSent = _client.add(reinterpret_cast<const char*>(_head->data(_sent)), willSend, ASYNC_WRITE_FLAG_COPY);  // flag is set by LWIP anyway, added for clarity
-      _sent += willSend;
-      (void)realSent;
+      // add() takes less than asked when tcp_write() hits ERR_MEM (returns 0) or when
+      // sndbuf shrank since space() was read (returns a short count). Advancing _sent by
+      // the requested amount drops those bytes for good: the broker then reads the head of
+      // the next packet as this one's tail and loses framing, which surfaces as malformed
+      // packets, bogus "QoS=0 and DUP=1", and keepalive reaps. Nothing was sent, so retry
+      // on the next _onAck()/_onPoll() rather than spinning here.
+      if (realSent == 0) break;
+      #if ASYNC_TCP_SSL_ENABLED
+      _sent += willSend;  // add() reports encrypted length, so count what we asked for
+      #else
+      _sent += realSent;
+      #endif
       _client.send();
       _lastClientActivity = millis();
       _lastPingRequestTime = 0;


### PR DESCRIPTION
`_handleQueue()` advances `_sent` by `willSend` and discards `add()`'s return value:

```cpp
size_t willSend = std::min(_head->size() - _sent, _client.space());
size_t realSent = _client.add(..., willSend, ASYNC_WRITE_FLAG_COPY);
_sent += willSend;   // requested
(void)realSent;      // actual — discarded
```

`AsyncClient::add()` can return less than requested:

- **0** when `tcp_write()` fails with `ERR_MEM` — reachable with `tcp_sndbuf() > 0` whenever the pbuf pool is exhausted or `TCP_SND_QUEUELEN` is full;
- **a short count** when sndbuf shrank between the `space()` read and the write.

Those bytes are never retransmitted, so the broker consumes the head of the next queued packet as the tail of the current one and loses the packet boundary. Downstream that surfaces as `malformed packet`, spurious `Invalid PUBLISH (QoS=0 and DUP=1)` (a misread flags nibble, not a real DUP), and keepalive reaps roughly 1.5x keepalive after the desync — three symptoms that look unrelated but share this one cause.

## Fix

Advance by `realSent`, and `break` when nothing went out so the queue is retried. This can't stall: both `onAck` and `onPoll` are registered in the constructor and re-enter `_handleQueue()`. `ASYNC_WRITE_FLAG_COPY` is set, so the unsent tail is still in the packet's buffer and resuming from a corrected `_sent` is safe. The SSL path keeps `willSend`, since `add()` reports encrypted length there — that's what the existing `(void)realSent` was accommodating.

## Evidence

Reported with a 26-node fleet analysis in ESPresense/ESPresense#2218 — 3,260 corrupt payloads over 14.86 d, reaps clustered in the 180–190 s bin (median 183 s = 1.5 × keepalive 120), permutation null 21.8% vs 91.7% observed.

Independently found and fixed the same way in abratchik/async-mqtt-client@182eff98, with no connection between the two reports.

A host-side harness modelling the cursor logic against a mock `add()` that fails as AsyncTCP's does, 500 randomized trials:

```
shipped code corrupt: 220
patched code corrupt: 0
```

The harness also asserts the queue fully drains, covering the `break` path.

For reference, `espMqttClient` does `_bytesSent += written` — same invariant, stated positively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbxF5tPKtubPws29RBwpwn