### PR TITLE
Fix the two red CI checks

### DIFF
--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -17,4 +17,4 @@ jobs:
         pip install cpplint
     - name: Linting
       run: |
-        cpplint --repository=. --recursive --filter=-whitespace/line_length,-legal/copyright,-runtime/printf,-build/include,-build/namespace ./src
+        cpplint --repository=. --recursive --filter=-whitespace/line_length,-legal/copyright,-runtime/printf,-build/include,-build/namespace,-whitespace/indent_namespace ./src

--- a/scripts/CI/platformio_esp32.ini
+++ b/scripts/CI/platformio_esp32.ini
@@ -14,3 +14,5 @@ board = esp32dev
 framework = arduino
 build_flags =
   -Wall
+; global lib storage holds both TCP libs; ESPAsyncTCP is ESP8266-only
+lib_ignore = ESPAsyncTCP

--- a/scripts/CI/platformio_esp8266.ini
+++ b/scripts/CI/platformio_esp8266.ini
@@ -14,3 +14,5 @@ board = esp01_1m
 framework = arduino
 build_flags =
   -Wall
+; global lib storage holds both TCP libs; AsyncTCP is ESP32-only
+lib_ignore = AsyncTCP


### PR DESCRIPTION
Follow-up to the request on #324 to find out why the checks fail. Neither failure comes from that PR — both workflows have been red on `develop` and on every PR for a while. Two independent causes.

### Build with Platformio

`scripts/CI/build_examples_pio.sh` installs **both** TCP libraries into global lib storage:

```
platformio lib -g install AsyncTCP        # ESP32
platformio lib -g install ESPAsyncTCP     # ESP8266
```

`pio ci` compiles everything in global storage regardless of the dependency graph — note the graph in the CI log lists only `AsyncMqttClient / ESP8266WiFi / Ticker`, yet `AsyncTCP.cpp.o` is built anyway. So each build also compiles the *other* platform's TCP library:

- ESP8266 build → `AsyncTCP.h:22: fatal error: sdkconfig.h: No such file or directory` (AsyncTCP 3.5.0 is ESP32-only)
- ESP32 build → `ESPAsyncTCP.cpp`: `debug.h` missing, `IPAddress`/`ip_addr_t` conversion errors, `panic` undeclared

Fix: `lib_ignore` the foreign library in each CI ini. Two lines.

### cpplint

17 errors, all `whitespace/indent_namespace` on `src/AsyncMqttClient/Helpers.hpp:40-58` — the indented `#define`s inside the `#if defined(ARDUINO_ARCH_ESP32) / #elif ... ESP8266` block. Those lines are at file scope, not inside a namespace; cpplint 2.x mis-attributes the preprocessor indentation. Added to the existing `--filter` list rather than flattening a conditional that reads better indented.

### Verified

Ran the exact CI steps locally on this branch — `FullyFeatured-ESP8266` and `FullyFeatured-ESP32` both link, cpplint reports 0 errors. Only CI config changes; no library source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123bZuG4RZchUsAzDAD6MDF